### PR TITLE
Ajustando imagem de fundo, topo

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5502
+}

--- a/landing-pagepp/landing.css
+++ b/landing-pagepp/landing.css
@@ -74,7 +74,9 @@
     display: flex;
     flex-direction: column;
     background-image: url("./midia/linda-garota-vestindo-camiseta-laranja-sorrindo-de-forma-positiva-e-feliz-apontando-com-o-dedo-para-o-lado-em-pe-sobre-um-fundo-laranja-isolado_141793-24589.png");
-    background-size: 100vw auto;
+    background-repeat: no-repeat;
+    background-size: 1000px auto;
+    background-position: top center;
     width: 100vw;
     height: 110vh;
     }

--- a/landing-pagepp/landing.html
+++ b/landing-pagepp/landing.html
@@ -63,6 +63,7 @@
                 <a href="https://github.com/LuizHenriqueMarinho" target="_blank"><img class="imagem-git" src="./midia/github.jpg"/></a> 
                 </p>       
             </footer>
+        </main>
     </div>
 </body>
 </html>


### PR DESCRIPTION
Ajustando a imagem de fundo da primeira imagem de topo, alterando de vw para px, de forma que a imagem permanecesse estática. Também incluído a propriedade background-repeat para evitar que a imagem se repetisse no dimensionamento da tela.